### PR TITLE
chore: mark tested up to WordPress 7.1

### DIFF
--- a/opcache-preload-generator.php
+++ b/opcache-preload-generator.php
@@ -9,7 +9,7 @@
  * Author URI: https://multisiteultimate.com
  * Copyright: David Stone, Multisite Ultimate
  * Requires at least: 5.3
- * Tested up to: 7.0
+ * Tested up to: 7.1
  * Requires PHP: 7.4
  *
  * @package OPcache_Preload_Generator

--- a/opcache-preload-generator.php
+++ b/opcache-preload-generator.php
@@ -9,7 +9,6 @@
  * Author URI: https://multisiteultimate.com
  * Copyright: David Stone, Multisite Ultimate
  * Requires at least: 5.3
- * Tested up to: 7.1
  * Requires PHP: 7.4
  *
  * @package OPcache_Preload_Generator

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: superdav42
 Tags: opcache, preload, performance, optimization, php
 Requires at least: 5.3
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 1.1.0
 License: GPLv3 or later


### PR DESCRIPTION
## Summary

- Keeps `Tested up to: 7.1` solely in the package `readme.txt`.
- Removes the field from the first-party plugin header.

## Verification

- `php -l` on the plugin entrypoint
- `git diff --check`
- Confirmed the readme has the exact field and the entrypoint header has none
